### PR TITLE
Run update before trying to install lcov

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -22,7 +22,6 @@ runs:
         NOCOLOR="\033[0m";
 
         apt-get -qq update
-
         apt-get install -q -y lcov
 
         echo -e "${BLUE}Capture coverage info${NOCOLOR}";

--- a/action.yaml
+++ b/action.yaml
@@ -21,6 +21,7 @@ runs:
         BLUE="\033[0;34m";
         NOCOLOR="\033[0m";
 
+        apt-get -qq update
         apt-get install -q lcov
 
         echo -e "${BLUE}Capture coverage info${NOCOLOR}";

--- a/action.yaml
+++ b/action.yaml
@@ -23,7 +23,7 @@ runs:
 
         apt-get -qq update
 
-        apt-get install -q lcov
+        apt-get install -q -y lcov
 
         echo -e "${BLUE}Capture coverage info${NOCOLOR}";
         lcov --capture --directory ${{ inputs.dir }} --output-file coverage.info

--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,7 @@ runs:
         NOCOLOR="\033[0m";
 
         apt-get -qq update
+
         apt-get install -q lcov
 
         echo -e "${BLUE}Capture coverage info${NOCOLOR}";


### PR DESCRIPTION
This was failing for MTC's ros2 branch, the reason is when we build the docker image we remove the lists directory